### PR TITLE
fix: Correct bot initialization and update owner number

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,7 +2,7 @@ export default {
   // Configuración del bot
   botName: "MiBot WhatsApp",
   ownerName: "Propietario del Bot",
-  ownerNumber: "1234567890@s.whatsapp.net", // Cambia por tu número
+  ownerNumber: "573133374132@s.whatsapp.net", // Cambia por tu número
   
   // APIs
   ytmp3API: "https://myapiadonix.vercel.app/api/ytmp3",


### PR DESCRIPTION
- Replaces the incorrect logger object with a `pino` logger instance to resolve the `logger.child is not a function` crash on startup.
- Removes the deprecated `printQRInTerminal` option from the `makeWASocket` configuration.
- Adds `pino` as a required dependency.
- Updates the `ownerNumber` in `config.js` with the user-provided phone number to ensure the bot responds to commands from the owner.